### PR TITLE
Clone shuffle input array before randomizing

### DIFF
--- a/src/lib/dataStore.ts
+++ b/src/lib/dataStore.ts
@@ -362,11 +362,12 @@ const examKey = (clientId: string, examId: string) => `exam:${clientId}:${examId
 const examResKey = (clientId: string, examId: string) => `examres:${clientId}:${examId}`;
 
 export function shuffle<T>(items: T[]): T[] {
-  for (let i = items.length - 1; i > 0; i--) {
+  const copy = items.slice();
+  for (let i = copy.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
-    [items[i], items[j]] = [items[j], items[i]];
+    [copy[i], copy[j]] = [copy[j], copy[i]];
   }
-  return items;
+  return copy;
 }
 
 export async function sampleQuestions(


### PR DESCRIPTION
## Summary
- clone the shuffle input array before running Fisher–Yates to avoid mutating callers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd05aa75408320b7e66dc45179d826