### PR TITLE
Add IP rate limiting and session controls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,17 @@ import { routeManagement } from "./routes/management";
 import { routeTaxonomy } from "./routes/taxonomy";
 import { html } from "./lib/http";
 import { getSessionUser, requireRole } from "./lib/auth";
+import { enforceRateLimit } from "./lib/rateLimit";
 
 export default {
   async fetch(req: Request, env: any, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(req.url);
     const p = url.pathname;
+
+    if (req.method !== "OPTIONS") {
+      const rateResponse = enforceRateLimit(req, env);
+      if (rateResponse) return rateResponse;
+    }
 
     // 1) auth
     { const r = routeAuth(req, url, env); if (r) return r; }

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,67 @@
+import { json } from "./http";
+import { getClientIp } from "./requestMeta";
+
+const DEFAULT_LIMIT = 120;
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULT_BLOCK_MS = 2 * 60_000;
+
+type RateBucket = {
+  count: number;
+  expiresAt: number;
+  blockedUntil?: number;
+};
+
+const rateBuckets = new Map<string, RateBucket>();
+
+function parseNumber(input: any, fallback: number): number {
+  const n = Number(input);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return n;
+}
+
+export function enforceRateLimit(req: Request, env: any): Response | null {
+  if (env && String(env.DISABLE_RATE_LIMIT) === "1") return null;
+
+  const ip = getClientIp(req) || "unknown";
+  const limit = parseNumber(env?.RATE_LIMIT_MAX_REQUESTS, DEFAULT_LIMIT);
+  const windowMs = parseNumber(env?.RATE_LIMIT_WINDOW_MS, DEFAULT_WINDOW_MS);
+  const blockMs = parseNumber(env?.RATE_LIMIT_BLOCK_MS, DEFAULT_BLOCK_MS);
+
+  const whitelist = String(env?.RATE_LIMIT_IP_WHITELIST || "")
+    .split(",")
+    .map((p: string) => p.trim())
+    .filter(Boolean);
+  if (whitelist.length && whitelist.includes(ip)) return null;
+
+  const now = Date.now();
+  const bucket = rateBuckets.get(ip);
+
+  if (bucket && bucket.blockedUntil && now < bucket.blockedUntil) {
+    const retryAfterSec = Math.ceil((bucket.blockedUntil - now) / 1000);
+    return json(
+      { ok: false, error: "rate_limited", retryAfter: retryAfterSec },
+      429,
+      { "Retry-After": String(retryAfterSec) }
+    );
+  }
+
+  if (!bucket || now >= bucket.expiresAt) {
+    rateBuckets.set(ip, { count: 1, expiresAt: now + windowMs });
+    return null;
+  }
+
+  bucket.count += 1;
+  if (bucket.count > limit) {
+    bucket.blockedUntil = now + blockMs;
+    rateBuckets.set(ip, bucket);
+    const retryAfterSec = Math.ceil(blockMs / 1000);
+    return json(
+      { ok: false, error: "rate_limited", retryAfter: retryAfterSec },
+      429,
+      { "Retry-After": String(retryAfterSec) }
+    );
+  }
+
+  rateBuckets.set(ip, bucket);
+  return null;
+}

--- a/src/lib/requestMeta.ts
+++ b/src/lib/requestMeta.ts
@@ -1,0 +1,19 @@
+export function getClientIp(req: Request): string {
+  const cf = req.headers.get("CF-Connecting-IP");
+  if (cf && cf.trim()) return cf.trim();
+
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff && xff.trim()) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+
+  const real = req.headers.get("X-Real-IP");
+  if (real && real.trim()) return real.trim();
+
+  return req.headers.get("Remote-Addr")?.trim() || "";
+}
+
+export function getUserAgent(req: Request): string {
+  return req.headers.get("user-agent") || "";
+}

--- a/src/lib/sessionStore.ts
+++ b/src/lib/sessionStore.ts
@@ -1,0 +1,131 @@
+import { getClientIp, getUserAgent } from "./requestMeta";
+
+const SESSION_KEY_PREFIX = "session:";
+const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const TOUCH_INTERVAL_MS = 60 * 1000; // 1 minute
+const DEFAULT_MAX_ACTIVE_SESSIONS = 2;
+
+export type SessionMeta = {
+  ip?: string;
+  ua?: string;
+};
+
+export type StoredSession = {
+  id: string;
+  createdAt: number;
+  lastSeenAt: number;
+  ip?: string;
+  ua?: string;
+};
+
+export const SESSION_COOKIE_NAME = "sid";
+export const SESSION_COOKIE_TTL_SEC = 60 * 60 * 24 * 30;
+
+function sessionKey(email: string) {
+  return SESSION_KEY_PREFIX + email.toLowerCase();
+}
+
+function parseNumber(input: any, fallback: number): number {
+  const n = Number(input);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return Math.floor(n);
+}
+
+async function readSessions(env: any, email: string): Promise<StoredSession[]> {
+  try {
+    const raw = await env.DATA.get(sessionKey(email));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((s: any) => typeof s?.id === "string" && s.id);
+  } catch {
+    return [];
+  }
+}
+
+async function writeSessions(env: any, email: string, sessions: StoredSession[]): Promise<void> {
+  if (!sessions.length) {
+    await env.DATA.delete(sessionKey(email));
+    return;
+  }
+  await env.DATA.put(sessionKey(email), JSON.stringify(sessions));
+}
+
+function sanitizeSessions(list: StoredSession[]): StoredSession[] {
+  const now = Date.now();
+  return list
+    .filter((s) => now - s.createdAt <= SESSION_TTL_MS)
+    .map((s) => ({ ...s }));
+}
+
+function getMaxSessions(env: any): number {
+  return parseNumber(env?.MAX_ACTIVE_SESSIONS, DEFAULT_MAX_ACTIVE_SESSIONS);
+}
+
+export function buildSessionCookie(token: string): string {
+  return `${SESSION_COOKIE_NAME}=${token}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${SESSION_COOKIE_TTL_SEC}`;
+}
+
+export function clearSessionCookie(): string {
+  return `${SESSION_COOKIE_NAME}=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0`;
+}
+
+export async function registerSession(env: any, req: Request, email: string, sessionId: string): Promise<void> {
+  const meta: SessionMeta = { ip: getClientIp(req), ua: getUserAgent(req) };
+  const now = Date.now();
+  const current = sanitizeSessions(await readSessions(env, email)).filter((s) => s.id !== sessionId);
+  current.push({ id: sessionId, createdAt: now, lastSeenAt: now, ip: meta.ip, ua: meta.ua });
+  current.sort((a, b) => a.createdAt - b.createdAt);
+
+  const max = getMaxSessions(env);
+  while (current.length > max) {
+    current.shift();
+  }
+
+  await writeSessions(env, email, current);
+}
+
+export async function ensureSessionActive(env: any, req: Request, email: string, sessionId?: string): Promise<boolean> {
+  if (!sessionId) return true;
+  const now = Date.now();
+  const rawSessions = await readSessions(env, email);
+  const sessions = sanitizeSessions(rawSessions);
+  let found = false;
+  let changed = sessions.length !== rawSessions.length;
+
+  const ip = getClientIp(req);
+  const ua = getUserAgent(req);
+
+  for (const s of sessions) {
+    if (s.id !== sessionId) continue;
+    found = true;
+    if (now - s.lastSeenAt >= TOUCH_INTERVAL_MS) {
+      s.lastSeenAt = now;
+      changed = true;
+    }
+    if (ip && ip !== s.ip) {
+      s.ip = ip;
+      changed = true;
+    }
+    if (ua && ua !== s.ua) {
+      s.ua = ua;
+      changed = true;
+    }
+  }
+
+  if (!found) {
+    if (changed) await writeSessions(env, email, sessions);
+    return false;
+  }
+
+  if (changed) await writeSessions(env, email, sessions);
+  return true;
+}
+
+export async function revokeSession(env: any, email: string, sessionId?: string): Promise<void> {
+  if (!sessionId) return;
+  const sessions = sanitizeSessions(await readSessions(env, email));
+  const next = sessions.filter((s) => s.id !== sessionId);
+  if (next.length === sessions.length) return;
+  await writeSessions(env, email, next);
+}


### PR DESCRIPTION
## Summary
- add an in-memory IP-based rate limiter with optional environment overrides and wiring in the Worker entrypoint
- introduce a KV-backed session store to cap concurrent logins, update active session metadata, and revoke sessions on logout
- include session identifiers in issued JWTs and use centralized helpers for session cookies

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e4fa742a4c832096915b6d296c9b35