### PR TITLE
Capture talifi metadata fields and cover filters

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -766,11 +766,9 @@ function formToQuestionPayload(fd: FormData, type: QuestionType): Omit<Question,
     stem: String(fd.get("stem") || ""),
   };
 
-  if (type === "konkur") {
-    payload.degreeId = optionalField(fd, "degreeId");
-    payload.ministryId = optionalField(fd, "ministryId");
-    payload.examYearId = optionalField(fd, "examYearId");
-  }
+  payload.degreeId = optionalField(fd, "degreeId");
+  payload.ministryId = optionalField(fd, "ministryId");
+  payload.examYearId = optionalField(fd, "examYearId");
   payload.sourceId = optionalField(fd, "sourceId");
   payload.chapterId = optionalField(fd, "chapterId");
   payload.expl = optionalField(fd, "expl");
@@ -794,11 +792,11 @@ function formToQuestionPayload(fd: FormData, type: QuestionType): Omit<Question,
 
 // فرم‌ساز
 function formHtml(action: string, withOptions: boolean, root: "k"|"t"|"q") {
-  const konkurMeta = root === "k" ? `
+  const metadataSelects = root === "q" ? "" : `
     <div><label>مقطع</label> <select id="${root}-degree" name="degreeId"></select></div>
     <div><label>وزارتخانه</label> <select id="${root}-ministry" name="ministryId"></select></div>
     <div><label>سال کنکور</label> <select id="${root}-examYear" name="examYearId"></select></div>
-  ` : "";
+  `;
   const optionalSourceChapter = root === "k" ? "" : `
     <div><label>منبع</label> <select id="${root}-source" name="sourceId"></select></div>
     <div><label>فصل</label> <select id="${root}-chapter" name="chapterId"></select></div>
@@ -806,7 +804,7 @@ function formHtml(action: string, withOptions: boolean, root: "k"|"t"|"q") {
   return `
   <form id="form-${root}" method="post" action="${action}">
     <div><label>رشته</label> <select id="${root}-major" name="majorId" required></select></div>
-    ${konkurMeta}
+    ${metadataSelects}
     <div><label>درس</label> <select id="${root}-course" name="courseId" required></select></div>
     ${optionalSourceChapter}
 

--- a/tests/admin-manage-list.test.ts
+++ b/tests/admin-manage-list.test.ts
@@ -200,6 +200,30 @@ async function run() {
     assert.equal(deepFiltered.meta?.total, 1);
     assert.equal(deepFiltered.meta?.hasMore, false);
 
+    const talifiUrl = new URL("https://example.com/api/admin/create?type=talifi");
+    const talifiForm = new URLSearchParams();
+    talifiForm.set("majorId", "talifi-major");
+    talifiForm.set("courseId", "talifi-course");
+    talifiForm.set("stem", "talifi question with metadata");
+    talifiForm.set("opt1", "option a");
+    talifiForm.set("opt2", "option b");
+    talifiForm.set("opt3", "option c");
+    talifiForm.set("opt4", "option d");
+    talifiForm.set("correctLabel", "3");
+    talifiForm.set("degreeId", "talifi-degree");
+    const talifiReq = new Request(talifiUrl, { method: "POST", body: talifiForm });
+    const talifiRes = await routeAdmin(talifiReq, talifiUrl, env);
+    assert.ok(talifiRes instanceof Response);
+    assert.equal(talifiRes.status, 200);
+    const talifiBody: any = await talifiRes.json();
+    assert.equal(talifiBody?.ok, true);
+    const talifiId = talifiBody?.id;
+    assert.ok(talifiId);
+
+    const talifiFiltered = await call({ type: "talifi", degreeId: "talifi-degree" });
+    assert.equal(talifiFiltered.data.length, 1);
+    assert.equal(talifiFiltered.data[0]?.id, talifiId);
+
     console.log("admin manage list supports filters and pagination");
   } finally {
     Date.now = restoreNow;


### PR DESCRIPTION
## Summary
- persist optional degree, ministry, and exam year metadata for every question type
- expose the shared metadata selects on the تالیفی authoring form so admins can submit values
- add a regression test to ensure تالیفی questions created through the API surface when filtered by degree

## Testing
- npx tsx tests/admin-manage-list.test.ts
- npx tsx tests/admin-create-talifi-qa.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69135e83dbfc832094befca71ef9f88a)